### PR TITLE
Improve decoupling of deploy script from CF

### DIFF
--- a/deploy/deploy
+++ b/deploy/deploy
@@ -127,19 +127,6 @@ test_chart() {
 export_variables() {
   # Export normally here so they are available to the post hook
   export URL=$url
-
-  # It is necessary to export these variables because we are using it on the pipelines
-  cf_export URL="$url"
-
-  # If APP_PREFIX is available we used it to prefix the exported variables
-  # This is useful when multiple deployments are done in the same pipeline.
-  # In such situation each deployment would override the variable of previous one.
-  if [ "$APP_PREFIX" != "" ]; then
-    # Replace dash (-) from app prefix by underscore (_)
-    valid_app_prefix=$(echo "$APP_PREFIX" | sed 's/\-/\_/g')
-    export "$valid_app_prefix"_URL="$url"
-    cf_export "$valid_app_prefix"_URL="$url"
-  fi
 }
 
 config_context

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -26,14 +26,15 @@ is_ephemeral=${APP_IS_EPHEMERAL:-true}
 host=$namespace.$APP_DOMAIN
 url=https://$host
 kube_context=$KUBE_CONTEXT
+kube_config_dir=$KUBE_CONFIG_DIR
 secrets_file=$SECRETS_FILE
 
 config_context() {
   # kubectl locks the config for each execution. To workaround
   # and allow multiple concurrent kubectl executions we copy the config
-  kubeconfig_dir=/codefresh/volume/sensitive/.kube-$namespace/
-  cp -R /codefresh/volume/sensitive/.kube "${kubeconfig_dir}"
-  export KUBECONFIG=${kubeconfig_dir}/config
+  scoped_kubeconfig_dir=$kube_config_dir-$namespace/
+  cp -R "$kube_config_dir" "${scoped_kubeconfig_dir}"
+  export KUBECONFIG=${scoped_kubeconfig_dir}/config
   kubectl config use-context "$kube_context"
 }
 

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -26,6 +26,7 @@ is_ephemeral=${APP_IS_EPHEMERAL:-true}
 host=$namespace.$APP_DOMAIN
 url=https://$host
 kube_context=$KUBE_CONTEXT
+secrets_file=$SECRETS_FILE
 
 config_context() {
   # kubectl locks the config for each execution. To workaround
@@ -63,11 +64,12 @@ EOF
 apply_secret() {
   # If the user doesn't have secrets we need to generate an empty file
   # to make our chart happy, without this the deployment breaks
-  if [ ! -f "/codefresh/volume/secrets.env" ]; then
-    touch /codefresh/volume/secrets.env
+  if [ "$secrets_file" != "" ]; then
+    secrets_file="secrets.env"
+    touch $secrets_file
   fi
 
-  kubectl create secret generic "$namespace" --from-env-file=/codefresh/volume/secrets.env --dry-run=client -o yaml --save-config=true --namespace "$namespace" | kubectl apply -f -
+  kubectl create secret generic "$namespace" --from-env-file=$secrets_file --dry-run=client -o yaml --save-config=true --namespace "$namespace" | kubectl apply -f -
 }
 
 install_chart() {

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -70,7 +70,8 @@ apply_secret() {
     touch $secrets_file
   fi
 
-  kubectl create secret generic "$namespace" --from-env-file=$secrets_file --dry-run=client -o yaml --save-config=true --namespace "$namespace" | kubectl apply -f -
+  kubectl create secret generic "$namespace" --from-env-file=$secrets_file \
+    --dry-run=client -o yaml --save-config=true --namespace "$namespace" | kubectl apply -f -
 }
 
 install_chart() {


### PR DESCRIPTION
One important thing for this project is to decouple it from CodeFresh. This way it will be much more useful to other people, so they can use it with whatever CI/CD tool, the same for us.

This PR is moving hard coded config of secrets, kube config file and cf_export to the pipeline itself. This bring a bit of complexity to the pipeline, but we can fix that later by using a CF step for that.