### PR TITLE
[ch27570] Move ci/cd pipelines to github actions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -32,11 +32,6 @@ jobs:
       - name: Clone
         uses: actions/checkout@v2
 
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -56,8 +51,8 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }} \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:master \
             --build-arg DEFAULT_HELM_REPO_URL=$DEFAULT_HELM_REPO_URL .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }}
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:master

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,29 @@
+name: cd
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Building Docker image
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: 934550854836.dkr.ecr.eu-west-1.amazonaws.com/cf-review-env-prod
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$${{ github.sha }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -5,15 +5,44 @@ on:
       - main
 
 jobs:
+  helm:
+    name: Push to the Repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v2
+
+      - name: Push
+        shell: bash
+        env:
+          HELM_REPO_ACCESS_TOKEN: ${{ secrets.CF_API_KEY }}
+          HELM_REPO_AUTH_HEADER: Authorization
+        run: |
+          helm version --short -c
+          helm plugin install https://github.com/chartmuseum/helm-push.git
+          helm repo add remote cm://h.cfcr.io/findhotel/default/
+          helm dependency build charts/kube-review || helm dependency update charts/kube-review || echo "dependencies cannot be updated"
+          PACKAGE="$(helm package charts/kube-review --destination /tmp | cut -d " " -f 8)"
+          helm push $PACKAGE remote
+
   build:
     name: Building Docker image
+    runs-on: ubuntu-latest
     steps:
+      - name: Clone
+        uses: actions/checkout@v2
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
+          aws-region: eu-west-1
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -22,8 +51,13 @@ jobs:
       - name: Build, tag, and push image to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: 934550854836.dkr.ecr.eu-west-1.amazonaws.com/cf-review-env-prod
+          ECR_REPOSITORY: cf-review-env-prod
+          DEFAULT_HELM_REPO_URL: cm://h.cfcr.io/findhotel/default/
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }} \
+            --build-arg DEFAULT_HELM_REPO_URL=$DEFAULT_HELM_REPO_URL .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$${{ github.sha }}
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
+          aws-region: eu-west-1
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,6 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: cf-review-env-prod
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }}
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,8 @@
 name: ci
 on:
   push:
-    branches:
-      - '!main'
+    branches-ignore:
+      - 'main'
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,34 @@
+name: ci
+on:
+  push:
+    branches:
+      - '!main'
+
+jobs:
+  build:
+    name: Building Docker image
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: 934550854836.dkr.ecr.eu-west-1.amazonaws.com/cf-review-env-prod
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }}
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,21 @@ on:
       - 'master'
 
 jobs:
-
+  helm:
+    name: Push to the Repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Push
+        shell: bash
+        env:
+          HELM_REPO_ACCESS_TOKEN: $CF_API_KEY
+          HELM_REPO_AUTH_HEADER: Authorization
+        run: |
+          helm version --short -c
+          helm repo add remote cm://h.cfcr.io/findhotel/lab/
+          helm dependency build charts/kube-review || helm dependency update charts/kube-review || echo "dependencies cannot be updated"
+          PACKAGE="$(helm package charts/kube-review --version 0.0.1+${{ github.sha }} --destination /tmp | cut -d " " -f 8)"
+          helm push $PACKAGE remote
 
   build:
     name: Building Docker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ jobs:
     name: Push to the Repository
     runs-on: ubuntu-latest
     steps:
+      - name: Clone
+        uses: actions/checkout@v2
+
       - name: Push
         shell: bash
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,12 @@ name: ci
 on:
   push:
     branches-ignore:
-      - 'main'
+      - 'master'
 
 jobs:
   build:
     name: Building Docker image
+    runs-on: ubuntu-latest
     steps:
       - name: Extract branch name
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Push
         shell: bash
         env:
-          HELM_REPO_ACCESS_TOKEN: $CF_API_KEY
+          HELM_REPO_ACCESS_TOKEN: ${{ secrets.CF_API_KEY }}
           HELM_REPO_AUTH_HEADER: Authorization
         run: |
           helm version --short -c

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,4 +36,5 @@ jobs:
           ECR_REPOSITORY: cf-review-env-prod
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }} .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
           HELM_REPO_AUTH_HEADER: Authorization
         run: |
           helm version --short -c
+          helm plugin install https://github.com/chartmuseum/helm-push.git
           helm repo add remote cm://h.cfcr.io/findhotel/lab/
           helm dependency build charts/kube-review || helm dependency update charts/kube-review || echo "dependencies cannot be updated"
           PACKAGE="$(helm package charts/kube-review --version 0.0.1+${{ github.sha }} --destination /tmp | cut -d " " -f 8)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Build, tag, and push image to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: 934550854836.dkr.ecr.eu-west-1.amazonaws.com/cf-review-env-prod
+          ECR_REPOSITORY: cf-review-env-prod
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,11 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: cf-review-env-prod
+          DEFAULT_HELM_REPO_URL: cm://h.cfcr.io/findhotel/lab/
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }} .
+          docker build  \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }} \
+            --build-arg DEFAULT_HELM_REPO_URL=$DEFAULT_HELM_REPO_URL .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,10 +5,15 @@ on:
       - 'master'
 
 jobs:
+
+
   build:
     name: Building Docker image
     runs-on: ubuntu-latest
     steps:
+      - name: Clone
+        uses: actions/checkout@v2
+
       - name: Extract branch name
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,5 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: cf-review-env-prod
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }}
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }} .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags


### PR DESCRIPTION
In order to move forward with our plan to make kube-review a true open source project, we need to have the ci/cd pipelines into a public place. Therefore we migrate from CF to github actions.