### PR TITLE
[ch22704] Implement kube review prune job as a k8s cronjob

### DIFF
--- a/charts/docs/helm-chart.md
+++ b/charts/docs/helm-chart.md
@@ -46,6 +46,19 @@ helm upgrade CHART_NAME ./kube-review \
 --wait
 ```
 
+The same for the `kube-review-prune` chart:
+
+```
+helm upgrade CHART_NAME ./kube-review-prune \
+--install \
+--reset-values \
+--namespace NAMESPACE_NAME \
+--wait  \
+--set image.tag=IMAGE_TAG \
+--set github.ghToken=GITHUB_TOKEN \
+--set github.ghUserName=GITHUB_USERNAME
+```
+
 ## How to Uninstall
 
 REF.: https://helm.sh/docs/helm/helm_uninstall/

--- a/charts/docs/helm-template.md
+++ b/charts/docs/helm-template.md
@@ -4,7 +4,7 @@ Ref.: https://helm.sh/docs/chart_template_guide/debugging/
 
 When will be necessary to add new changes on the templates file it's possible to do a debug and then to check if the new change is correct or not, basically you need to run this command:
 
-`helm template test kube-review -f kube-review/values.yaml --debug \
+`helm template kube-review -f kube-review/values.yaml --debug \
 --set envFrom.secretRef.name=SECRET_NAME \
 --set image.repository=IMAGE_REPOSITORY_URL/IMAGE_REPOSITORY_NAME \
 --set image.tag=IMAGE_TAG \
@@ -14,3 +14,7 @@ When will be necessary to add new changes on the templates file it's possible to
 --set "ingress.tls[0].hosts[0]=HOST_NAME.shared-prod.fih.io"`
 
 **Note:** It's necessary to use a true `values.yaml` file.
+
+To debug the `kube-review-prune` chart you can run:
+
+`helm template CHART_NAME kube-review-prune --debug`

--- a/charts/kube-review-prune/.helmignore
+++ b/charts/kube-review-prune/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kube-review-prune/Chart.yaml
+++ b/charts/kube-review-prune/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+appVersion: 0.1
+name: kube-review-prune
+description: Helm chart that deploys a kube-review prune job
+keywords:
+  - review
+  - environment
+  - prune
+maintainers:
+  - name: FindHotel
+type: application
+sources:
+- https://github.com/FindHotel/kube-review
+version: 0.1

--- a/charts/kube-review-prune/templates/_helpers.tpl
+++ b/charts/kube-review-prune/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kube-review-prune.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kube-review-prune.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kube-review-prune.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kube-review-prune.labels" -}}
+helm.sh/chart: {{ include "kube-review-prune.chart" . }}
+{{ include "kube-review-prune.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kube-review-prune.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kube-review-prune.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kube-review-prune.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kube-review-prune.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/kube-review-prune/templates/clusterole.yaml
+++ b/charts/kube-review-prune/templates/clusterole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: namespace-cleaner
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "delete"]

--- a/charts/kube-review-prune/templates/clusterolebinding.yaml
+++ b/charts/kube-review-prune/templates/clusterolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: namespace-cleaner-global
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kube-review-prune.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: namespace-cleaner
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/kube-review-prune/templates/cronjob.yaml
+++ b/charts/kube-review-prune/templates/cronjob.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "kube-review-prune.fullname" . }}
+  labels:
+    {{- include "kube-review-prune.labels" . | nindent 4 }}
+spec:
+  schedule: "@hourly"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "kube-review-prune.selectorLabels" . | nindent 12 }}
+        spec:
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+              command: ['{{ .Values.command }}']
+              args:
+                - '--ghToken={{ .Values.github.ghToken }}'
+                - '--ghUserName={{ .Values.github.ghUserName }}'
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+          restartPolicy: {{ .Values.restartPolicy | default "OnFailure" }}
+          serviceAccountName: {{ include "kube-review-prune.serviceAccountName" . }}

--- a/charts/kube-review-prune/templates/serviceaccount.yaml
+++ b/charts/kube-review-prune/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kube-review-prune.serviceAccountName" . }}
+  labels:
+    {{- include "kube-review-prune.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kube-review-prune/values.yaml
+++ b/charts/kube-review-prune/values.yaml
@@ -1,0 +1,16 @@
+serviceAccount:
+  create: true
+resources:
+  limits:
+    cpu: "1"
+    memory: 600Mi
+  requests:
+    cpu: 100m
+    memory: 600Mi
+image:
+  repository: 934550854836.dkr.ecr.eu-west-1.amazonaws.com/cf-review-env-prod
+  tag: latest
+command: /prune
+github:
+  ghToken: YOURTOKENHEE
+  ghUserName: YOURUSERNAMEHERE

--- a/prune/main.go
+++ b/prune/main.go
@@ -149,6 +149,11 @@ type K8sNamespace struct {
 }
 
 func buildConfigFromFlags(contextName, kubeconfigPath string) (*rest.Config, error) {
+	if kubeconfigPath == "" {
+		log.Printf("No kube config file informed, using in cluster config")
+		return rest.InClusterConfig()
+	}
+
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
 		&clientcmd.ConfigOverrides{
@@ -317,13 +322,13 @@ func main() {
 		},
 		&cli.StringFlag{
 			Name:     "k8sKubeconfig",
-			Usage:    "absolute path to the kubeconfig file",
-			Required: true,
+			Usage:    "absolute path to the kubeconfig file, if not informed will use in cluster config",
+			Required: false,
 		},
 		&cli.StringFlag{
 			Name:     "k8sContextName",
 			Usage:    "the k8s context name to operate on",
-			Required: true,
+			Required: false,
 		},
 		&cli.StringFlag{
 			Name:  "ghEndpoint",


### PR DESCRIPTION
Instead of using CF cron build, this will implement the kube-review-prune process a k8s cron job. This will make easier for people to install both prune and app as helm charts. One more step towards a real open source project that can be used outside FH.