### PR TITLE
Add missing labels and proper resource name to kube-review-prune chart

### DIFF
--- a/charts/kube-review-prune/templates/clusterole.yaml
+++ b/charts/kube-review-prune/templates/clusterole.yaml
@@ -1,7 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: namespace-cleaner
+  name: {{ include "kube-review-prune.fullname" . }}
+  labels:
+    {{- include "kube-review-prune.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]

--- a/charts/kube-review-prune/templates/clusterolebinding.yaml
+++ b/charts/kube-review-prune/templates/clusterolebinding.yaml
@@ -1,12 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: namespace-cleaner-global
+  name: {{ include "kube-review-prune.fullname" . }}
+  labels:
+    {{- include "kube-review-prune.labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "kube-review-prune.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: namespace-cleaner
+  name: {{ include "kube-review-prune.fullname" . }}
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Add required labels by helm and use a proper name.