### PR TITLE
[ch27571] Start using dockerhub instead of ecr

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,27 +35,21 @@ jobs:
       - name: Clone
         uses: actions/checkout@v2
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            findhotelamsterdam/kube-review:${{ github.sha }}
+            findhotelamsterdam/kube-review:${{ steps.extract_branch.outputs.branch }}
+            findhotelamsterdam/kube-review:latest
+          build-args: |
+            DEFAULT_HELM_REPO_URL=cm://h.cfcr.io/findhotel/lab/
 
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: cf-review-env-prod
-          DEFAULT_HELM_REPO_URL: cm://h.cfcr.io/findhotel/default/
-        run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:master \
-            --build-arg DEFAULT_HELM_REPO_URL=$DEFAULT_HELM_REPO_URL .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:master

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -48,8 +48,8 @@ jobs:
           push: true
           tags: |
             findhotelamsterdam/kube-review:${{ github.sha }}
-            findhotelamsterdam/kube-review:${{ steps.extract_branch.outputs.branch }}
+            findhotelamsterdam/kube-review:master
             findhotelamsterdam/kube-review:latest
           build-args: |
-            DEFAULT_HELM_REPO_URL=cm://h.cfcr.io/findhotel/lab/
+            DEFAULT_HELM_REPO_URL=cm://h.cfcr.io/findhotel/default/
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
           tags: |
             findhotelamsterdam/kube-review:${{ github.sha }}
             findhotelamsterdam/kube-review:${{ steps.extract_branch.outputs.branch }}
-          build-args:
-            - ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}
-            - ECR_REPOSITORY=cf-review-env-prod
-            - DEFAULT_HELM_REPO_URL=cm://h.cfcr.io/findhotel/lab/
+          build-args: |
+            ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}
+            ECR_REPOSITORY=cf-review-env-prod
+            DEFAULT_HELM_REPO_URL=cm://h.cfcr.io/findhotel/lab/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,13 +40,6 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
-
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,8 +58,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags:
-            - findhotelamsterdam/kube-review:${{ github.sha }},findhotelamsterdam/kube-review:${{ steps.extract_branch.outputs.branch }}
+          tags: |
+            findhotelamsterdam/kube-review:${{ github.sha }}
+            findhotelamsterdam/kube-review:${{ steps.extract_branch.outputs.branch }}
           build-args:
             - ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}
             - ECR_REPOSITORY=cf-review-env-prod

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,8 +59,7 @@ jobs:
         with:
           push: true
           tags:
-            - findhotelamsterdam/kube-review:${{ github.sha }}
-            - findhotelamsterdam/kube-review:${{ steps.extract_branch.outputs.branch }}
+            - findhotelamsterdam/kube-review:${{ github.sha }},findhotelamsterdam/kube-review:${{ steps.extract_branch.outputs.branch }}
           build-args:
             - ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}
             - ECR_REPOSITORY=cf-review-env-prod

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,19 +47,21 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build, tag, and push image to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: cf-review-env-prod
-          DEFAULT_HELM_REPO_URL: cm://h.cfcr.io/findhotel/lab/
-        run: |
-          docker build  \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }} \
-            --build-arg DEFAULT_HELM_REPO_URL=$DEFAULT_HELM_REPO_URL .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.extract_branch.outputs.branch }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags:
+            - findhotelamsterdam/kube-review:${{ github.sha }}
+            - findhotelamsterdam/kube-review:${{ steps.extract_branch.outputs.branch }}
+          build-args:
+            - ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}
+            - ECR_REPOSITORY=cf-review-env-prod
+            - DEFAULT_HELM_REPO_URL=cm://h.cfcr.io/findhotel/lab/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,4 @@ jobs:
             findhotelamsterdam/kube-review:${{ github.sha }}
             findhotelamsterdam/kube-review:${{ steps.extract_branch.outputs.branch }}
           build-args: |
-            ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}
-            ECR_REPOSITORY=cf-review-env-prod
             DEFAULT_HELM_REPO_URL=cm://h.cfcr.io/findhotel/lab/


### PR DESCRIPTION
Start using the public image from docker hub registry.