### PR TITLE
[ch31379] - fixing warnings for the ingress extensions

### DIFF
--- a/charts/kube-review/Chart.yaml
+++ b/charts/kube-review/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.3
+appVersion: 0.4
 name: kube-review
 description: Helm chart that deploys a kube-review app
 keywords:
@@ -10,4 +10,4 @@ maintainers:
 type: application
 sources:
 - https://github.com/FindHotel/kube-review
-version: 0.3
+version: 0.4

--- a/charts/kube-review/templates/ingress.yaml
+++ b/charts/kube-review/templates/ingress.yaml
@@ -30,7 +30,7 @@ spec:
           {{- range .paths }}
           - path: {{ . }}
             pathType: Prefix
-            backend:
+            defaultBackend:
               service:
                 name: {{ $fullName }}
                 port:

--- a/charts/kube-review/templates/ingress.yaml
+++ b/charts/kube-review/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kube-review.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else -}}
-apiVersion: networking.k8s.io/v1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,9 +29,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/kube-review/templates/ingress.yaml
+++ b/charts/kube-review/templates/ingress.yaml
@@ -2,9 +2,9 @@
 {{- $fullName := include "kube-review.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- end }}
 kind: Ingress
 metadata:

--- a/charts/kube-review/templates/ingress.yaml
+++ b/charts/kube-review/templates/ingress.yaml
@@ -30,7 +30,7 @@ spec:
           {{- range .paths }}
           - path: {{ . }}
             pathType: Prefix
-            defaultBackend:
+            backend:
               service:
                 name: {{ $fullName }}
                 port:

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -7,7 +7,7 @@ if [ "$KR_PRE_HOOK" != "" ]; then
   eval "$KR_PRE_HOOK"
 fi
 
-chart_version=${KR_CHART_VERSION:-0.3}
+chart_version=${KR_CHART_VERSION:-0.4}
 helm_version=${KR_HELM_VERSION:-3.1.1}
 chart_ref=${KR_CHART_REF:-kube-review}
 


### PR DESCRIPTION
https://app.clubhouse.io/findhotel/story/31379/fix-warnings-on-kubernetes-1-19

This warning is about the Ingress extensions:

`extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress`

New syntax for ingress template:

https://kubernetes.io/docs/concepts/services-networking/ingress/

It was tested here:

https://g.codefresh.io/build/6065cd5f697c2246551478cc