### PR TITLE
Change prune chart default values file to use docker hub image

### DIFF
--- a/charts/kube-review-prune/values.yaml
+++ b/charts/kube-review-prune/values.yaml
@@ -8,8 +8,9 @@ resources:
     cpu: 100m
     memory: 600Mi
 image:
-  repository: 934550854836.dkr.ecr.eu-west-1.amazonaws.com/cf-review-env-prod
+  repository: findhotelamsterdam/kube-review
   tag: latest
+  pullPolicy: Always
 command: /prune
 github:
   ghToken: YOURTOKENHEE


### PR DESCRIPTION
The installation of the kube-review-prune chart should use the docker hub image. So, this changes the default values file to point to the correct docker registry.