### PR TITLE
ci flow changed to use current time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
           helm push $PACKAGE remote
           helm repo update
-          helm search repo -l lab/kube-review | grep 0.0.1-$TIME
+          helm search repo -l lab/kube-review
 
   build:
     name: Building Docker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get current time
-        uses: 1466587594/get-current-time@v2.0.0
-        with:
-          format: YYYYMMDD-HH
-          utcOffset: "+08:00"
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H:%M:%S')"
+
       - name: Clone
         uses: actions/checkout@v2
 
@@ -22,7 +21,7 @@ jobs:
         env:
           HELM_REPO_ACCESS_TOKEN: ${{ secrets.CF_API_KEY }}
           HELM_REPO_AUTH_HEADER: Authorization
-          TIME: "${{ steps.current-time.outputs.time }}"
+          TIME: "${{steps.date.outputs.date}}"
         run: |
           helm version --short -c
           helm plugin install https://github.com/chartmuseum/helm-push.git

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,17 +21,19 @@ jobs:
         env:
           HELM_REPO_ACCESS_TOKEN: ${{ secrets.CF_API_KEY }}
           HELM_REPO_AUTH_HEADER: Authorization
+          HELM_REPO_NAME: cm://h.cfcr.io/findhotel/lab/
+          HELM_REPO_PLUGIN_NAME: https://github.com/chartmuseum/helm-push.git
           TIME: "${{steps.date.outputs.date}}"
         run: |
           helm version --short -c
-          helm plugin install https://github.com/chartmuseum/helm-push.git
-          helm repo add remote cm://h.cfcr.io/findhotel/lab/
+          helm plugin install $HELM_REPO_PLUGIN_NAME
+          helm repo add remote $HELM_REPO_NAME
           helm dependency build charts/kube-review || helm dependency update charts/kube-review || echo "dependencies cannot be updated"
-          KUBE_REVIEW_PACKAGE="$(helm package charts/kube-review --version 0.0.1-$TIME --destination /tmp)"
-          helm push $KUBE_REVIEW_PACKAGE remote
+          PACKAGE="$(helm package charts/kube-review --version 0.0.1-$TIME --destination /tmp)"
+          helm push $PACKAGE remote
           helm dependency build charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
-          KUBE_REVIEW_PRUNE_PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp)"
-          helm push $KUBE_REVIEW_PRUNE_PACKAGE remote
+          PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp)"
+          helm push $PACKAGE remote
           helm repo update
 
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,11 +27,12 @@ jobs:
           helm plugin install https://github.com/chartmuseum/helm-push.git
           helm repo add remote cm://h.cfcr.io/findhotel/lab/
           helm dependency build charts/kube-review || helm dependency update charts/kube-review || echo "dependencies cannot be updated"
-          PACKAGE="$(helm package charts/kube-review --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
-          helm push $PACKAGE remote
+          KUBE_REVIEW_PACKAGE="$(helm package charts/kube-review --version 0.0.1-$TIME --destination /tmp)"
+          helm push $KUBE_REVIEW_PACKAGE remote
           helm dependency build charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
-          PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
-          helm push $PACKAGE remote
+          KUBE_REVIEW_PRUNE_PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp)"
+          helm push $KUBE_REVIEW_PRUNE_PACKAGE remote
+          helm repo update
 
   build:
     name: Building Docker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
           PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
           helm push $PACKAGE remote
           helm repo update
+          helm search repo -l lab/kube-review | grep 0.0.1-$TIME
 
   build:
     name: Building Docker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Get current time
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H:%M:%S')"
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M-%S')"
 
       - name: Clone
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,10 @@ jobs:
           helm plugin install $HELM_REPO_PLUGIN_NAME
           helm repo add remote $HELM_REPO_NAME
           helm dependency build charts/kube-review || helm dependency update charts/kube-review || echo "dependencies cannot be updated"
-          PACKAGE="$(helm package charts/kube-review --version 0.0.1-$TIME --destination /tmp)"
+          PACKAGE="$(helm package charts/kube-review --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
           helm push $PACKAGE remote
           helm dependency build charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
-          PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp)"
+          PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
           helm push $PACKAGE remote
           helm repo update
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,11 @@ jobs:
     name: Push to the Repository
     runs-on: ubuntu-latest
     steps:
+      - name: Get current time
+        uses: 1466587594/get-current-time@v2.0.0
+        with:
+          format: YYYYMMDD-HH
+          utcOffset: "+08:00"
       - name: Clone
         uses: actions/checkout@v2
 
@@ -22,10 +27,10 @@ jobs:
           helm plugin install https://github.com/chartmuseum/helm-push.git
           helm repo add remote cm://h.cfcr.io/findhotel/lab/
           helm dependency build charts/kube-review || helm dependency update charts/kube-review || echo "dependencies cannot be updated"
-          PACKAGE="$(helm package charts/kube-review --version 0.0.1+${{ github.sha }} --destination /tmp | cut -d " " -f 8)"
+          PACKAGE="$(helm package charts/kube-review --version 0.0.1-${{ steps.current-time.outputs.time }} --destination /tmp | cut -d " " -f 8)"
           helm push $PACKAGE remote
           helm dependency build charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
-          PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1+${{ github.sha }} --destination /tmp | cut -d " " -f 8)"
+          PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-${{ steps.current-time.outputs.time }} --destination /tmp | cut -d " " -f 8)"
           helm push $PACKAGE remote
 
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,15 +22,16 @@ jobs:
         env:
           HELM_REPO_ACCESS_TOKEN: ${{ secrets.CF_API_KEY }}
           HELM_REPO_AUTH_HEADER: Authorization
+          TIME: "${{ steps.current-time.outputs.time }}"
         run: |
           helm version --short -c
           helm plugin install https://github.com/chartmuseum/helm-push.git
           helm repo add remote cm://h.cfcr.io/findhotel/lab/
           helm dependency build charts/kube-review || helm dependency update charts/kube-review || echo "dependencies cannot be updated"
-          PACKAGE="$(helm package charts/kube-review --version 0.0.1-${{ steps.current-time.outputs.time }} --destination /tmp | cut -d " " -f 8)"
+          PACKAGE="$(helm package charts/kube-review --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
           helm push $PACKAGE remote
           helm dependency build charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
-          PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-${{ steps.current-time.outputs.time }} --destination /tmp | cut -d " " -f 8)"
+          PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
           helm push $PACKAGE remote
 
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,8 +34,6 @@ jobs:
           helm dependency build charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
           PACKAGE="$(helm package charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
           helm push $PACKAGE remote
-          helm repo update
-          helm search repo -l lab/kube-review
 
   build:
     name: Building Docker image

--- a/charts/kube-review-prune/Chart.yaml
+++ b/charts/kube-review-prune/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.3
+appVersion: 0.2
 name: kube-review-prune
 description: Helm chart that deploys a kube-review prune job
 keywords:
@@ -11,4 +11,4 @@ maintainers:
 type: application
 sources:
 - https://github.com/FindHotel/kube-review
-version: 0.3
+version: 0.2

--- a/charts/kube-review-prune/Chart.yaml
+++ b/charts/kube-review-prune/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.2
+appVersion: 0.3
 name: kube-review-prune
 description: Helm chart that deploys a kube-review prune job
 keywords:
@@ -11,4 +11,4 @@ maintainers:
 type: application
 sources:
 - https://github.com/FindHotel/kube-review
-version: 0.2
+version: 0.3


### PR DESCRIPTION
Currently, for devel helm charts we are creating them with this standard

`0.0.1+${{ github.sha }} = 0.0.1+36388f21f99c05de85406c367ab4915a740fad4b`

And it is making hard to identify what is the latest version of the chart when we need to run `helm install` command, for example, for the `kube-review-prune` the latest version is `0.0.1+e7a5a7f847bef724c9d35b11e29eb154c14413c2` and when we try to install it we are getting the version `0.0.1+c10329c62c028dcf8832d60bdd733c939a759f78`.

Trying to fix it, I'd like to purpose a new standard following [terraform documents](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#devel) and using `current time`, like this:

`0.0.1-${{steps.date.outputs.date}} = 0.0.1-2021-05-27-10-00-33`