### PR TITLE
[ch31792] - pin version of kube review chart version removed

### DIFF
--- a/charts/kube-review/Chart.yaml
+++ b/charts/kube-review/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.5
+appVersion: 0.6
 name: kube-review
 description: Helm chart that deploys a kube-review app
 keywords:
@@ -10,4 +10,4 @@ maintainers:
 type: application
 sources:
 - https://github.com/FindHotel/kube-review
-version: 0.5
+version: 0.6

--- a/charts/kube-review/Chart.yaml
+++ b/charts/kube-review/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.6
+appVersion: 0.5
 name: kube-review
 description: Helm chart that deploys a kube-review app
 keywords:
@@ -10,4 +10,4 @@ maintainers:
 type: application
 sources:
 - https://github.com/FindHotel/kube-review
-version: 0.6
+version: 0.5

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -8,7 +8,7 @@ if [ "$KR_PRE_HOOK" != "" ]; then
 fi
 
 # Helm Chart variables
-chart_version=${KR_CHART_VERSION:-0.5}
+chart_version=${KR_CHART_VERSION}
 chart_ref=${KR_CHART_REF:-kube-review}
 
 # DockerHub variables

--- a/deploy/deploy
+++ b/deploy/deploy
@@ -115,6 +115,7 @@ uninstall_chart() {
 install_chart() {
   (set -x; helm plugin install https://github.com/chartmuseum/helm-push.git || true)
   (set -x; helm repo add remote "$helm_repo")
+  (set -x; helm repo update)
 
   if [ "$KR_VALUES_FILE" != "" ]; then
     echo "Using values file from user: $KR_VALUES_FILE"


### PR DESCRIPTION
https://app.clubhouse.io/findhotel/story/31792/improve-version-installing-of-kube-review

It was tested here:

Kube Review current version (APP version 0.5): https://g.codefresh.io/build/60c86afcdc923c3b4009ac4d

<img width="1493" alt="Screen Shot 2021-06-15 at 11 08 39 AM" src="https://user-images.githubusercontent.com/11336131/122025907-0d96b300-cdca-11eb-8ded-f4080794bd60.png">

Kube Review a new bump version (APP version 0.6): https://g.codefresh.io/build/60c86c99850bdb6aec2222c7

<img width="1503" alt="Screen Shot 2021-06-15 at 11 08 49 AM" src="https://user-images.githubusercontent.com/11336131/122025922-1091a380-cdca-11eb-92ae-98a33ae8b7f1.png">

Note: I did these tests just to confirm if we really will get the latest version every time.
