### PR TITLE
[ch35272] - cronjob apiversion updated and TTL controler parameter added

### DIFF
--- a/charts/kube-review-prune/templates/cronjob.yaml
+++ b/charts/kube-review-prune/templates/cronjob.yaml
@@ -1,10 +1,11 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "kube-review-prune.fullname" . }}
   labels:
     {{- include "kube-review-prune.labels" . | nindent 4 }}
 spec:
+  ttlSecondsAfterFinished: 300
   schedule: "@hourly"
   jobTemplate:
     spec:


### PR DESCRIPTION
https://app.clubhouse.io/findhotel/story/35272/update-kube-review-prune-with-ttl-controller-parameter

CHANGES in Cronjob file:

- `apiversion` updated from `batch/v1beta1` to `batch/v1`
- `ttlSecondsAfterFinished` parameter added as a new feature

EKS reference: https://aws.amazon.com/blogs/containers/amazon-eks-1-20-released/|
K8S reference: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/#ttl-controller
