### PR TITLE
Trigger actions cd pipeline only when a release is published

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,8 +1,7 @@
 name: cd
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published, created, edited]
 
 jobs:
   helm:
@@ -48,8 +47,7 @@ jobs:
           push: true
           tags: |
             findhotelamsterdam/kube-review:${{ github.sha }}
-            findhotelamsterdam/kube-review:master
-            findhotelamsterdam/kube-review:latest
+            findhotelamsterdam/kube-review:${{github.event.release.tag_name}}
           build-args: |
             DEFAULT_HELM_REPO_URL=cm://h.cfcr.io/findhotel/default/
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -47,7 +47,7 @@ jobs:
           push: true
           tags: |
             findhotelamsterdam/kube-review:${{ github.sha }}
-            findhotelamsterdam/kube-review:${{github.event.release.tag_name}}
+            findhotelamsterdam/kube-review:${{ github.event.release.tag_name }}
           build-args: |
             DEFAULT_HELM_REPO_URL=cm://h.cfcr.io/findhotel/default/
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,5 @@
 name: ci
-on:
-  push:
-    branches-ignore:
-      - 'master'
+on: push
 
 jobs:
   helm:


### PR DESCRIPTION
Start triggering the cd pipeline on releases. This will allow us to have versioned releases instead of the current latest/master schema. This will allow us to pin the version of kube-review used in the pipelines. Which makes easy to select which release one wants to use. Besides, this is a much better practice.

After this PR is merged I will update all pipelines to point to the 0.5 release, the current one.