### PR TITLE
Ignore tags on ci flow and avoid dupe build on cd

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,7 +1,7 @@
 name: cd
 on:
   release:
-    types: [published, created, edited]
+    types: [published, edited]
 
 jobs:
   helm:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: ci
-on: push
+on:
+  push:
+    tags-ignore:
+      - '**'
 
 jobs:
   helm:


### PR DESCRIPTION
Quick fix to make CI ignore tag builds and to only have one build when a tag is published.