### PR TITLE
Remove version from resource files and move instance value to annotations

### DIFF
--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -75,8 +75,8 @@ install_resources () {
   fi
 
   kustomize edit set namespace "$namespace"
-  kustomize edit set label "app.kubernetes.io/instance:$namespace"
   kustomize edit add annotation --force \
+  app.kubernetes.io/instance:"$namespace" \
   app.kubernetes.io/pull_request_number:"$pull_request_number" \
   app.kubernetes.io/branch_name:"$branch_name" \
   app.kubernetes.io/repository_name:"$repo_name" \

--- a/src/deploy/resources/base/kustomization.yaml
+++ b/src/deploy/resources/base/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: kube-review-
-commonAnnotations:
-    app.kubernetes.io/version: "0.5"
 commonLabels:
   app.kubernetes.io/name: kube-review
 resources:


### PR DESCRIPTION
Remove version from resource files to make release easier. Also, move instance value to annotation instead of labels as the prune job expects it to be there.