### PR TITLE
Changing Container Image field to use only one argument as a value

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -16,13 +16,20 @@ jobs:
         env:
           HELM_REPO_ACCESS_TOKEN: ${{ secrets.CF_API_KEY }}
           HELM_REPO_AUTH_HEADER: Authorization
+          HELM_REPO_NAME: cm://h.cfcr.io/findhotel/default/
+          #HELM_REPO_PLUGIN_NAME: https://github.com/chartmuseum/helm-push.git
+          # Since Helm version v3.7.0 there is a bug related to helm push
+          # https://github.com/chartmuseum/helm-push/issues/109
+          # As an alternative, there is this PR https://github.com/chartmuseum/helm-push/pull/110
+          HELM_REPO_PLUGIN_NAME: https://github.com/emanuelflp/helm-push.git
         run: |
           helm version --short -c
-          helm plugin install https://github.com/chartmuseum/helm-push.git
-          helm repo add remote cm://h.cfcr.io/findhotel/default/
+          helm plugin install $HELM_REPO_PLUGIN_NAME
+          helm repo add remote $HELM_REPO_NAME
           helm dependency build src/prune/charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
           PACKAGE="$(helm package src/prune/charts/kube-review-prune --destination /tmp | cut -d " " -f 8)"
-          helm push $PACKAGE remote
+          #helm push $PACKAGE remote
+          helm legacy-push $PACKAGE remote
 
   build:
     name: Building Docker image

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,7 +28,6 @@ jobs:
           helm repo add remote $HELM_REPO_NAME
           helm dependency build src/prune/charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
           PACKAGE="$(helm package src/prune/charts/kube-review-prune --destination /tmp | cut -d " " -f 8)"
-          #helm push $PACKAGE remote
           helm legacy-push $PACKAGE remote
 
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,6 @@ jobs:
           helm repo add remote $HELM_REPO_NAME
           helm dependency build src/prune/charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
           PACKAGE="$(helm package src/prune/charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
-          #helm push $PACKAGE remote
           helm legacy-push $PACKAGE remote
 
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
           HELM_REPO_NAME: cm://h.cfcr.io/findhotel/lab/
           HELM_REPO_PLUGIN_NAME: https://github.com/chartmuseum/helm-push.git
           TIME: "${{steps.date.outputs.date}}"
+          HELM_EXPERIMENTAL_OCI: 1
         run: |
           helm version --short -c
           helm plugin install $HELM_REPO_PLUGIN_NAME

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,8 @@ jobs:
         env:
           HELM_REPO_ACCESS_TOKEN: ${{ secrets.CF_API_KEY }}
           HELM_REPO_AUTH_HEADER: Authorization
-          HELM_REPO_NAME: cm://h.cfcr.io/findhotel/lab/
-          HELM_REPO_PLUGIN_NAME: https://github.com/chartmuseum/helm-push.git
+          HELM_REPO_NAME: cm://h.cfcr.io/findhotel/lab
+          HELM_REPO_PLUGIN_NAME: https://github.com/chartmuseum/helm-push
           TIME: "${{steps.date.outputs.date}}"
         run: |
           helm version --short -c
@@ -32,7 +32,7 @@ jobs:
           helm repo add remote $HELM_REPO_NAME
           helm dependency build src/prune/charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
           PACKAGE="$(helm package src/prune/charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
-          HELM_EXPERIMENTAL_OCI=1 helm push $PACKAGE cm://h.cfcr.io/findhotel/lab/
+          HELM_EXPERIMENTAL_OCI=1 helm push $PACKAGE remote
 
   build:
     name: Building Docker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,8 @@ jobs:
           helm plugin install $HELM_REPO_PLUGIN_NAME
           helm repo add remote $HELM_REPO_NAME
           helm dependency build src/prune/charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
-          export HELM_EXPERIMENTAL_OCI=1
           PACKAGE="$(helm package src/prune/charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
-          HELM_EXPERIMENTAL_OCI=1 helm push $PACKAGE remote
+          HELM_EXPERIMENTAL_OCI=1 helm push $PACKAGE cm://h.cfcr.io/findhotel/lab/
 
   build:
     name: Building Docker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,12 @@ jobs:
         env:
           HELM_REPO_ACCESS_TOKEN: ${{ secrets.CF_API_KEY }}
           HELM_REPO_AUTH_HEADER: Authorization
-          HELM_REPO_NAME: cm://h.cfcr.io/findhotel/lab
-          HELM_REPO_PLUGIN_NAME: https://github.com/chartmuseum/helm-push
+          HELM_REPO_NAME: cm://h.cfcr.io/findhotel/lab/
+          #HELM_REPO_PLUGIN_NAME: https://github.com/chartmuseum/helm-push.git
+          # Since, Helm version v3.7.0 there is a bug related to helm push
+          # https://github.com/chartmuseum/helm-push/issues/109
+          # As paliative alternative, there is this PR https://github.com/chartmuseum/helm-push/pull/110
+          HELM_REPO_PLUGIN_NAME: https://github.com/emanuelflp/helm-push.git
           TIME: "${{steps.date.outputs.date}}"
         run: |
           helm version --short -c
@@ -32,7 +36,7 @@ jobs:
           helm repo add remote $HELM_REPO_NAME
           helm dependency build src/prune/charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
           PACKAGE="$(helm package src/prune/charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
-          HELM_EXPERIMENTAL_OCI=1 helm push $PACKAGE remote
+          helm push $PACKAGE remote
 
   build:
     name: Building Docker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,8 @@ jobs:
           helm repo add remote $HELM_REPO_NAME
           helm dependency build src/prune/charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
           PACKAGE="$(helm package src/prune/charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
-          helm push $PACKAGE remote
+          #helm push $PACKAGE remote
+          helm legacy-push $PACKAGE remote
 
   build:
     name: Building Docker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,14 +26,14 @@ jobs:
           HELM_REPO_NAME: cm://h.cfcr.io/findhotel/lab/
           HELM_REPO_PLUGIN_NAME: https://github.com/chartmuseum/helm-push.git
           TIME: "${{steps.date.outputs.date}}"
-          HELM_EXPERIMENTAL_OCI: 1
         run: |
           helm version --short -c
           helm plugin install $HELM_REPO_PLUGIN_NAME
           helm repo add remote $HELM_REPO_NAME
           helm dependency build src/prune/charts/kube-review-prune || helm dependency update charts/kube-review-prune || echo "dependencies cannot be updated"
+          export HELM_EXPERIMENTAL_OCI=1
           PACKAGE="$(helm package src/prune/charts/kube-review-prune --version 0.0.1-$TIME --destination /tmp | cut -d " " -f 8)"
-          helm push $PACKAGE remote
+          HELM_EXPERIMENTAL_OCI=1 helm push $PACKAGE remote
 
   build:
     name: Building Docker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,9 @@ jobs:
           HELM_REPO_AUTH_HEADER: Authorization
           HELM_REPO_NAME: cm://h.cfcr.io/findhotel/lab/
           #HELM_REPO_PLUGIN_NAME: https://github.com/chartmuseum/helm-push.git
-          # Since, Helm version v3.7.0 there is a bug related to helm push
+          # Since Helm version v3.7.0 there is a bug related to helm push
           # https://github.com/chartmuseum/helm-push/issues/109
-          # As paliative alternative, there is this PR https://github.com/chartmuseum/helm-push/pull/110
+          # As an alternative, there is this PR https://github.com/chartmuseum/helm-push/pull/110
           HELM_REPO_PLUGIN_NAME: https://github.com/emanuelflp/helm-push.git
           TIME: "${{steps.date.outputs.date}}"
         run: |

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -70,8 +70,7 @@ Finally, in order to use the overlay one has to specify the `KR_OVERLAY_PATH` va
 
 ```
 KR_ID=nginx \
-KR_IMAGE_URL=nginx \
-KR_IMAGE_TAG=latest \
+KR_IMAGE=nginx:latest \
 KR_DOMAIN="my-domain.io" \
 KR_CONTAINER_PORT="80" \
 KR_OVERLAY_PATH=src/deploy/resources/example \

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -15,8 +15,7 @@ The `deploy` components contains many options which can be passed as environment
 | Name | Description | Default Value | Required |
 | - | - | - | - |
 | KR_ID | A unique identifier for the review environment. It's recommended this to be the branch name. | - | true |
-| KR_IMAGE_URL | The url of the container image that the app should run. | - | true |
-| KR_IMAGE_TAG | The tag of the container image that the app should run. | - | true |
+| KR_IMAGE | The full url of the container image, including the tag that the app should run. | - | true |
 | KR_DOMAIN | The domain on which the app should be available. e.g: `foo.com` | - | true |
 | KR_CONTAINER_PORT | The port exposed by the main container. | - | true |
 | KR_KUBE_CONTEXT | The kube context from the kube config file that should be used. | Default to current context. | false |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -15,7 +15,7 @@ The `deploy` components contains many options which can be passed as environment
 | Name | Description | Default Value | Required |
 | - | - | - | - |
 | KR_ID | A unique identifier for the review environment. It's recommended this to be the branch name. | - | true |
-| KR_IMAGE | The full url of the container image, including the tag that the app should run. | - | true |
+| KR_IMAGE | The full url of the container image, including the tag that the app should run. e.g: `KR_IMAGE=123456789012.dkr.ecr.eu-west-1.amazonaws.com/ecr-repo-name@sha256:2de5d881318951e48c69987df478b076f2b2ac9971d12f1b342347ed51ff7f4b` | - | true |
 | KR_DOMAIN | The domain on which the app should be available. e.g: `foo.com` | - | true |
 | KR_CONTAINER_PORT | The port exposed by the main container. | - | true |
 | KR_KUBE_CONTEXT | The kube context from the kube config file that should be used. | Default to current context. | false |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -15,7 +15,7 @@ The `deploy` components contains many options which can be passed as environment
 | Name | Description | Default Value | Required |
 | - | - | - | - |
 | KR_ID | A unique identifier for the review environment. It's recommended this to be the branch name. | - | true |
-| KR_IMAGE | The full url of the container image, including the tag that the app should run. e.g: `KR_IMAGE=123456789012.dkr.ecr.eu-west-1.amazonaws.com/ecr-repo-name@sha256:2de5d881318951e48c69987df478b076f2b2ac9971d12f1b342347ed51ff7f4b` | - | true |
+| KR_IMAGE | The full url of the container image, including the tag that the app should run. e.g: `KR_IMAGE=nginx:stable` | - | true |
 | KR_DOMAIN | The domain on which the app should be available. e.g: `foo.com` | - | true |
 | KR_CONTAINER_PORT | The port exposed by the main container. | - | true |
 | KR_KUBE_CONTEXT | The kube context from the kube config file that should be used. | Default to current context. | false |

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -156,8 +156,7 @@ Note that this example is using kustomize overlays to add a redis as a sidecar c
 With this command we will deploy a container running Nginx as a review env:
     
     KR_ID=nginx \
-    KR_IMAGE_URL=nginx \
-    KR_IMAGE_TAG=latest \
+    KR_IMAGE=nginx:latest \
     KR_DOMAIN="${MY_DOMAIN}" \
     KR_CONTAINER_PORT="80" \
     KR_OVERLAY_PATH=src/deploy/resources/example \

--- a/src/deploy/resources/base/deployment.yml
+++ b/src/deploy/resources/base/deployment.yml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: kube-review
-          image: "PLACEHOLDER:PLACEHOLDER"
+          image: "PLACEHOLDER"
           imagePullPolicy: IfNotPresent
           env:
             - name: KR_HOST

--- a/src/deploy/resources/base/patches/deployment.patch.json
+++ b/src/deploy/resources/base/patches/deployment.patch.json
@@ -2,7 +2,7 @@
     {
         "op": "replace",
         "path": "/spec/template/spec/containers/0/image", 
-        "value": "$KR_IMAGE_URL"
+        "value": "$KR_IMAGE"
     },
     {
         "op": "replace",

--- a/src/deploy/resources/base/patches/deployment.patch.json
+++ b/src/deploy/resources/base/patches/deployment.patch.json
@@ -2,7 +2,7 @@
     {
         "op": "replace",
         "path": "/spec/template/spec/containers/0/image", 
-        "value": "$KR_IMAGE_URL:$KR_IMAGE_TAG"
+        "value": "$KR_IMAGE_URL"
     },
     {
         "op": "replace",


### PR DESCRIPTION
- Changing `Kube-Review` deployment file to use only one argument in `Container Image`, making it possible to use a full URL of the Image URL repository plus tag.
- Changing parameter `KR_IMAGE_URL` to `KR_IMAGE`
- Github Workflow updated fixing an error related to helm `v3.7.0`.
Since `Helm version v3.7.0` there is a bug related to [helm push - issue](https://github.com/chartmuseum/helm-push/issues/109). As an alternative, there is this [pull request](https://github.com/chartmuseum/helm-push/pull/110)

With these changes will be possible to use only one parameter to specify the `Docker Image` on deployments in `Kube-Review`, like this: `KR_IMAGE=nginx:stable`