### PR TITLE
force delete pod before deleting namespace

### DIFF
--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -89,6 +89,7 @@ install_resources () {
   fi
 
   if [ "$delete_before_apply" != false ]; then
+    kubectl --namespace "$namespace" delete pods --all --grace-period=0 --force
     kubectl delete namespace "$namespace" --wait=true --ignore-not-found=true
   fi
 


### PR DESCRIPTION
Sometimes, during the `kube-review` deployment step, the `namespace` deleting is spending a lot of time to delete the pod stuck in `Terminating` status raising a timeout error in Codefresh.

<img width="650" alt="Screen Shot 2021-10-07 at 12 18 39 AM" src="https://user-images.githubusercontent.com/11336131/136315242-76568efa-354c-4f50-98a5-09aef400e9e2.png">
