### PR TITLE
adding --retry-delay parameter in test execution

### DIFF
--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -120,7 +120,7 @@ test_url() {
   then
     full_url=$url$test_connection_url_path
     echo "Running connection test against: $full_url"
-    output=$(curl --silent --fail --retry 3 "$full_url")
+    output=$(curl --silent --fail --retry 3 --retry-delay 5 "$full_url")
     if [[ $? != 0 ]]; then
       echo "Connection test has failed with the following test output: $output";
       exit 1;


### PR DESCRIPTION
As we agreed, I am adding `--retry-delay` in test execution trying to fix the error during test execution in the `kube-review` environment.
Example: https://g.codefresh.io/build/615ee8a14875a197c49d132f?step=deploy_core&tab=output&logs=terminal