### PR TITLE
changing the KR_DELETE_BEFORE_APPLY parameter value

### DIFF
--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -34,7 +34,7 @@ test_connection=${KR_TEST_CONNECTION:-true}
 test_connection_url_path=${KR_TEST_CONNECTION_URL_PATH:-"/"}
 overlay_path=$KR_OVERLAY_PATH
 base_overlay_path=${KR_BASE_OVERLAY_PATH:-"src/deploy/resources/base"}
-delete_before_apply=${KR_DELETE_BEFORE_APPLY:-false}
+delete_before_apply=${KR_DELETE_BEFORE_APPLY:-true}
 
 updated_at=$(date +%s)
 


### PR DESCRIPTION
To keep all new deployments in Kube Review consistent, I would like to enable the `KR_DELETE_BEFORE_APPLY` parameter by default as we had in Helm deployments. For now, we don't have any issue related to it but that change is just to avoid possible issues related to old or wrong settings from the old deployments.