### PR TITLE
[ch39737] - adding kubectl log command for verbose mode

### DIFF
--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -111,8 +111,10 @@ install_resources () {
   kubectl rollout status --timeout=5m -n "$namespace" deployment/kube-review-deployment
 
   if [ "$verbose" = "true" ]; then
+      echo "Verbose mode Enabled - Describing Pods"
       kubectl -n "$namespace" describe pods
-      kubectl -n "$namespace" logs deployment/kube-review-deployment --container kube-review --tail 50
+      echo "Verbose mode Enabled - Showing Pods Logs"
+      kubectl -n "$namespace" logs deployment/kube-review-deployment --all-containers=true
   fi
 }
 

--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -111,7 +111,8 @@ install_resources () {
   kubectl rollout status --timeout=5m -n "$namespace" deployment/kube-review-deployment
 
   if [ "$verbose" = "true" ]; then
-      kubectl describe -n "$namespace" pods
+      kubectl -n "$namespace" describe pods
+      kubectl -n "$namespace" logs deployment/kube-review-deployment --container kube-review --tail 50
   fi
 }
 


### PR DESCRIPTION
https://app.shortcut.com/findhotel/story/39737/show-pods-logs-in-kube-review-when-used-the-kr-verbose-parameter

- Adding `kubectl logs` command to expose POD logs from deployments

It has been tested:

https://g.codefresh.io/build/6203db9cc7bfd729393d3d16

<img width="1749" alt="Screen Shot 2022-02-09 at 4 28 23 PM" src="https://user-images.githubusercontent.com/11336131/153233103-8c59f45a-4e67-44d6-b5ca-79d9f06acfb8.png">
