### PR TITLE
[ch39737] - adding kubectl log command for verbose mode

### DIFF
--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -111,7 +111,10 @@ install_resources () {
   kubectl rollout status --timeout=5m -n "$namespace" deployment/kube-review-deployment
 
   if [ "$verbose" = "true" ]; then
-      kubectl describe -n "$namespace" pods
+      echo "Verbose mode Enabled - Describing Pods"
+      kubectl -n "$namespace" describe pods
+      echo "Verbose mode Enabled - Showing Pods Logs"
+      kubectl -n "$namespace" logs deployment/kube-review-deployment --all-containers=true
   fi
 }
 


### PR DESCRIPTION
https://app.shortcut.com/findhotel/story/39737/show-pods-logs-in-kube-review-when-used-the-kr-verbose-parameter

- Adding kubectl logs command to expose POD logs from deployments