### PR TITLE
[ingress-nginx] - adding selector in service.yaml file

### DIFF
--- a/src/deploy/resources/base/service.yml
+++ b/src/deploy/resources/base/service.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kube-review
+  name: service
 spec:
   type: ClusterIP
   selector:

--- a/src/deploy/resources/base/service.yml
+++ b/src/deploy/resources/base/service.yml
@@ -1,12 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: service
+  name: kube-review
 spec:
   type: ClusterIP
+  selector:
+    app.kubernetes.io/name: kube-review
   ports:
     - name: web
       protocol: TCP
       port: 80
       targetPort: 8080
-


### PR DESCRIPTION
Trying to fix the errors below in `ingress-nginx service`, I have added a selector in service.yaml file:

```
selector:
  app.kubernetes.io/name: kube-review
```

<img width="1103" alt="Screen Shot 2022-03-01 at 3 25 57 PM" src="https://user-images.githubusercontent.com/11336131/156187170-e4880a95-c3ea-4016-adce-fa010e02b779.png">
