### PR TITLE
feat: logs & describe from deployed Pods

### DIFF
--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -123,19 +123,21 @@ install_resources () {
 
   kubectl rollout status --timeout=5m -n "$namespace" deployment/kube-review-deployment
 
-  echo "Describing Deployed Pods"
-  kubectl -n "$namespace" describe pods
-  echo "Showing Namespace Events"
-  kubectl -n "$namespace" get events
+  if [ $? -ne 0 ]; then
+    echo "Rollout was not Successful... Describing Deployed Pods"
+    kubectl -n "$namespace" describe pods
+    echo "Showing Namespace Events"
+    kubectl -n "$namespace" get events
 
-  if [ "$verbose" = "true" ]; then
-    echo "[VERBOSE] Showing Pods Logs"
-    for pod_names in $(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n "$namespace" --field-selector status.phase=Running)
-    do
-      echo "Logs from Pod '"$pod_names"'" "in" the Namespace "'"$namespace"':"
-      kubectl -n "$namespace" logs "$pod_names" --all-containers=true
-      echo
-    done
+    if [ "$verbose" = "true" ]; then
+      echo "[VERBOSE] Showing Pods Logs"
+      for pod_names in $(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n "$namespace" --field-selector status.phase=Running)
+      do
+        echo "Logs from Pod '"$pod_names"'" "in" the Namespace "'"$namespace"':"
+        kubectl -n "$namespace" logs "$pod_names" --all-containers=true
+        echo
+      done
+    fi
   fi
 }
 

--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -123,12 +123,15 @@ install_resources () {
 
   kubectl rollout status --timeout=5m -n "$namespace" deployment/kube-review-deployment
 
-  if [ "$verbose" = "true" ]; then
-      echo "Verbose mode Enabled - Describing Pods"
-      kubectl -n "$namespace" describe pods
-      echo "Verbose mode Enabled - Showing Pods Logs"
-      kubectl -n "$namespace" logs deployment/kube-review-deployment --all-containers=true
-  fi
+  echo "Describing Deployed Pods"
+  kubectl -n "$namespace" describe pods
+  for pod_names in $(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n $namespace)
+  do
+    echo "Logs from Pod '"$pod_names"'" "in" the Namespace "'"$namespace"':"
+    kubectl -n $namespace logs $pod_names --all-containers=true
+    echo
+  done
+
 }
 
 test_url() {

--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -125,6 +125,7 @@ install_resources () {
 
   echo "Describing Deployed Pods"
   kubectl -n "$namespace" describe pods
+  echo "Showing Namespace Events"
   kubectl -n "$namespace" get events
 
   if [ "$verbose" = "true" ]; then
@@ -136,7 +137,6 @@ install_resources () {
       echo
     done
   fi
-
 }
 
 test_url() {

--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -125,12 +125,17 @@ install_resources () {
 
   echo "Describing Deployed Pods"
   kubectl -n "$namespace" describe pods
-  for pod_names in $(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n $namespace)
-  do
-    echo "Logs from Pod '"$pod_names"'" "in" the Namespace "'"$namespace"':"
-    kubectl -n $namespace logs $pod_names --all-containers=true
-    echo
-  done
+  kubectl -n "$namespace" get events
+
+  if [ "$verbose" = "true" ]; then
+    echo "[VERBOSE] Showing Pods Logs"
+    for pod_names in $(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n "$namespace" --field-selector status.phase=Running)
+    do
+      echo "Logs from Pod '"$pod_names"'" "in" the Namespace "'"$namespace"':"
+      kubectl -n "$namespace" logs "$pod_names" --all-containers=true
+      echo
+    done
+  fi
 
 }
 


### PR DESCRIPTION
- Describe deployed pods no longer depends on verbose = true.
- Logs are collected from Deployed pods and printed to the output console.