### PR TITLE
changing the cronjob API version to batch/v1

### DIFF
--- a/src/prune/charts/kube-review-prune/templates/cronjob.yaml
+++ b/src/prune/charts/kube-review-prune/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "kube-review-prune.fullname" . }}


### PR DESCRIPTION
Changing the cronjob API version from `batch/v1beta1` to `batch/v1`.

`2022-05-25 12:40:28 UTC | CLUSTER | WARN | (klog@v1.0.1-0.20200310124935-4ad0115ba9e4/klog.go:1207 in Warning) | batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob`