### PR TITLE
[ch52127] Add a restart command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,11 @@ COPY src/deploy kube-review/deploy/
 RUN chmod +x kube-review/deploy/deploy
 RUN ln -s /usr/local/kube-review/deploy/deploy /deploy
 
+RUN mkdir -p kube-review/restart
+COPY src/restart kube-review/restart/
+RUN chmod +x kube-review/restart/restart
+RUN ln -s /usr/local/kube-review/restart/restart /restart
+
 RUN mkdir -p kube-review/prune
 COPY --from=base /prune kube-review/prune/
 RUN chmod +x kube-review/prune/prune

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -4,13 +4,17 @@ The `kube-review` is composed of two main components, `deploy` and `prune`.
 
 ## Deploy Component
 
-The deploy component is a `bash` script that can be used to deploy a review environment. At it's core it's a simple script that will do all the necessary magic to get a review env running. Therefore, the `deploy` component is a command that is called every-time that an environment needs to created or updated.
+The deploy component contains a set of commands that can be used to manage review environments. These are simple scripts that will do all the necessary magic to manage a review environment. 
 
-The basic flow of the components is, configure the correct kube context, create the resources, and test the installation. Depending on the use case, some other features might be used, like running pre/post scripts.
+### Deploy Command
 
-### Options
+Deploy create or update a review environment.
 
-The `deploy` components contains many options which can be passed as environment variables. This is the list of all options:
+The basic flow of the components is, configure the correct kube context, create/update the resources, and test the installation. Depending on the use case, some other features might be used, like running pre/post scripts.
+
+#### Options
+
+The `deploy` command contains many options which can be passed as environment variables. This is the list of all options:
 
 | Name | Description | Default Value | Required |
 | - | - | - | - |
@@ -32,6 +36,29 @@ The `deploy` components contains many options which can be passed as environment
 | KR_POST_HOOK | A shell command to be executed after the deployment is finished. | - | false |
 | KR_BASE_OVERLAY_PATH | The path containing the base kustomize overlay to be used. | src/deploy/resources/base | false |
 | KR_OVERLAY_PATH | The path containing a kustomize overlay to be used. | - | false |
+| KR_VERBOSE | Prints verbose or debug messages. Should not be used in production. | false | false |
+
+### Restart Command
+
+Restarts an already deployed review environment.
+
+The basic flow of the components is, configure the correct kube context, restart the service, and test the installation. Depending on the use case, some other features might be used, like running pre/post scripts.
+
+#### Options
+
+The `restart` command contains many options which can be passed as environment variables. This is the list of all options:
+
+| Name | Description | Default Value | Required |
+| - | - | - | - |
+| KR_ID | A unique identifier for the review environment. It's recommended this to be the branch name. | - | true |
+| KR_DOMAIN | The domain on which the app should be available. e.g: `foo.com` | - | true |
+| KR_KUBE_CONTEXT | The kube context from the kube config file that should be used. | Default to current context. | false |
+| KR_PREFIX | A prefix to be added to the name of the environment. | re | false |
+| KR_KUBE_CONFIG_FILE | The kube config file used for connecting to Kuberneres. The file has to be accessible on the local file system during execution of the script. | $HOME/.kube/config | false |
+| KR_TEST_CONNECTION | Enable/disable testing the url of the environment once the deployment is done. If the connection fails the deployment will also fails. | true | false |
+| KR_TEST_CONNECTION_URL_PATH | A custom url path to be appended to the final url when running a connection test. | / | false |
+| KR_PRE_HOOK | A shell command to be executed before the deployment starts. | - | false |
+| KR_POST_HOOK | A shell command to be executed after the deployment is finished. | - | false |
 | KR_VERBOSE | Prints verbose or debug messages. Should not be used in production. | false | false |
 
 ## Prune Component

--- a/src/restart/restart
+++ b/src/restart/restart
@@ -1,0 +1,98 @@
+#!/bin/bash
+# exit if any command fails
+set -e
+
+verbose=${KR_VERBOSE:-false}
+if [ "$verbose" != "false" ]; then
+  set -x
+  export
+fi
+# Kube Review variables
+prefix=${KR_PREFIX:-re}
+kube_config_file=${KR_KUBE_CONFIG_FILE:-$HOME/.kube/config}
+name="$prefix-${KR_ID_OVERRIDE:-$KR_ID}"
+short_name=$(echo "$name" | cut -c1-15 | awk '{print tolower($0)}')
+hash=$(echo "$name" | rhash -p "%c" -)
+namespace=$short_name-$hash
+host=$namespace.$KR_DOMAIN
+url=https://$host
+kube_context=$KR_KUBE_CONTEXT
+test_connection=${KR_TEST_CONNECTION:-true}
+test_connection_url_path=${KR_TEST_CONNECTION_URL_PATH:-"/"}
+
+export_variables() {
+  # Export normally here so they are available to the post hook
+  export URL=$url
+}
+
+print_preinstall_message() {
+  echo "Environment will be deployed with url: $url"
+
+  if [ "$KR_MESSAGE" != "" ]; then
+    printf "%s\n" "$KR_MESSAGE" "$KR_LOG_URL$namespace"
+  fi
+}
+
+config_context() {
+  # kubectl locks the config for each execution. To workaround
+  # and allow multiple concurrent kubectl executions we copy the config
+  scoped_kubeconfig_file=$kube_config_file-$namespace
+  cp "$kube_config_file" "$scoped_kubeconfig_file"
+  export KUBECONFIG=${scoped_kubeconfig_file}
+
+  if [ "$kube_context" != "" ]; then
+    kubectl config use-context "$kube_context"
+  fi
+}
+
+install_resources () {
+  # Rollout is necessary to force loading of secrets when only the secrets is updated
+  echo "Re-deployment, executing rollout";
+  kubectl rollout restart -n "$namespace" deployment/kube-review-deployment    
+  kubectl rollout status --timeout=5m -n "$namespace" deployment/kube-review-deployment
+
+  if [ $? -ne 0 ]; then
+    echo "Rollout was not Successful... Describing Deployed Pods"
+    kubectl -n "$namespace" describe pods
+    echo "Showing Namespace Events"
+    kubectl -n "$namespace" get events
+
+    if [ "$verbose" = "true" ]; then
+      echo "[VERBOSE] Showing Pods Logs"
+      for pod_names in $(kubectl get pods --no-headers -o custom-columns=":metadata.name" -n "$namespace" --field-selector status.phase=Running)
+      do
+        echo "Logs from Pod '"$pod_names"'" "in" the Namespace "'"$namespace"':"
+        kubectl -n "$namespace" logs "$pod_names" --all-containers=true
+        echo
+      done
+    fi
+  fi
+}
+
+test_url() {
+  if [ "$test_connection" = true ];
+  then
+    full_url=$url$test_connection_url_path
+    echo "Running connection test against: $full_url"
+    output=$(curl --silent --fail --retry 3 "$full_url")
+    if [[ $? != 0 ]]; then
+      echo "Connection test has failed with the following test output: $output";
+      exit 1;
+    else
+      echo "Connection test executed successfully";
+    fi
+  else
+    echo "Connection test is disabled";
+  fi
+}
+
+export_variables
+print_preinstall_message
+config_context
+restart
+test_url
+
+if [ "$KR_POST_HOOK" != "" ]; then
+  echo "Running post hook command: $KR_POST_HOOK"
+  eval "$KR_POST_HOOK"
+fi

--- a/src/restart/restart
+++ b/src/restart/restart
@@ -45,7 +45,7 @@ config_context() {
   fi
 }
 
-install_resources () {
+restart() {
   # Rollout is necessary to force loading of secrets when only the secrets is updated
   echo "Re-deployment, executing rollout";
   kubectl rollout restart -n "$namespace" deployment/kube-review-deployment    

--- a/src/restart/restart
+++ b/src/restart/restart
@@ -7,6 +7,12 @@ if [ "$verbose" != "false" ]; then
   set -x
   export
 fi
+
+if [ "$KR_PRE_HOOK" != "" ]; then
+  echo "Running pre hook command: $KR_PRE_HOOK"
+  eval "$KR_PRE_HOOK"
+fi
+
 # Kube Review variables
 prefix=${KR_PREFIX:-re}
 kube_config_file=${KR_KUBE_CONFIG_FILE:-$HOME/.kube/config}


### PR DESCRIPTION
Implement a restart command, so that we can just restart review envs without re-deploy. This makes it possible to restart a review env outside of the repo that contains the overlay files.

Used here https://github.com/FindHotel/github-actions/pull/13/files#diff-abeec520ad6e301dd9d714135a1c647c0cd073c46ded4817eddcf1b20fac57dcR34 and here https://github.com/FindHotel/raa-profiles/pull/1676/files#diff-5e0e118103b95ac1f259bb84f2c73c382a5f7cdfc0fe816f2c867765a5016f0aR110