### PR TITLE
fix: change bash to -e so code 1 will not exit execution

### DIFF
--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -1,6 +1,6 @@
 #!/bin/bash
-# exit if any command fails
-set -e
+# overrides default `set -e`: Do not exit if a command fails.
+set +e
 
 verbose=${KR_VERBOSE:-false}
 if [ "$verbose" != "false" ]; then

--- a/src/restart/restart
+++ b/src/restart/restart
@@ -1,6 +1,6 @@
 #!/bin/bash
-# exit if any command fails
-set -e
+# overrides default `set -e`: Do not exit if a command fails.
+set +e
 
 verbose=${KR_VERBOSE:-false}
 if [ "$verbose" != "false" ]; then


### PR DESCRIPTION
Currently, the deafult option is to exit `kube-review` in the case of command exit code != 0 with `set -e`.  It prevents from debug steps to run as the case of of collecting Kubernetes events and logs where corresponding exceptions are being handled within those affected steps. This PR aims to change `kube-review` so it will not stop in the case of an exit code != 0 by changing `set +e`.