### PR TITLE
feat: get major version and set as image tag

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -42,6 +42,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Get major release version
+        id: major_release
+        run: |
+          echo "::set-output name=MAJOR_VERSION::$(echo ${{ github.event.release.tag_name }} | cut -d '.' -f1)"
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v3
@@ -50,6 +55,7 @@ jobs:
           tags: |
             findhotelamsterdam/kube-review:latest
             findhotelamsterdam/kube-review:${{ github.event.release.tag_name }}
+            findhotelamsterdam/kube-review:"${{ steps.major_release.outputs.MAJOR_VERSION }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |


### PR DESCRIPTION
With this method images will be added with a major release tag. This tag can be referenced from other pipelines as latest stable from a determined major version removing the demand of bumping specific version to use the latest stable version within a major release.

Reference - Stable Tags:
https://stevelasker.blog/2018/03/01/docker-tagging-best-practices-for-tagging-and-versioning-docker-images/