### PR TITLE
Stop deletion of non-ephemeral envs when PR is merged

### DIFF
--- a/src/prune/main.go
+++ b/src/prune/main.go
@@ -292,17 +292,19 @@ func run(c *cli.Context) error {
 		log.Printf("Name: %s Duration: %s, Expired: %t, Merged: %t, Ephemeral: %t",
 			namespace.Name, time.Since(*namespace.UpdatedAt), expired, merged, namespace.IsEphemeral)
 
-		if expired || merged {
-			if !c.Bool("dryRun") {
-				if err := k8sClient.DeleteNamespace(namespace.Name); err != nil {
-					log.Printf("error deleting k8s namespace: %s", err)
-					continue
+		if merged && namespace.IsEphemeral {
+			continue
+			if expired || merged {
+				if !c.Bool("dryRun") {
+					if err := k8sClient.DeleteNamespace(namespace.Name); err != nil {
+						log.Printf("error deleting k8s namespace: %s", err)
+						continue
+					}
 				}
-			}
 
-			log.Printf("K8s namespace deleted: %s", namespace.Name)
+				log.Printf("K8s namespace deleted: %s", namespace.Name)
+			}
 		}
-	}
 	return nil
 }
 

--- a/src/prune/main.go
+++ b/src/prune/main.go
@@ -292,19 +292,17 @@ func run(c *cli.Context) error {
 		log.Printf("Name: %s Duration: %s, Expired: %t, Merged: %t, Ephemeral: %t",
 			namespace.Name, time.Since(*namespace.UpdatedAt), expired, merged, namespace.IsEphemeral)
 
-		if merged && namespace.IsEphemeral {
-			continue
-			if expired || merged {
-				if !c.Bool("dryRun") {
-					if err := k8sClient.DeleteNamespace(namespace.Name); err != nil {
-						log.Printf("error deleting k8s namespace: %s", err)
-						continue
-					}
+		if expired || (merged && namespace.IsEphemeral) {
+			if !c.Bool("dryRun") {
+				if err := k8sClient.DeleteNamespace(namespace.Name); err != nil {
+					log.Printf("error deleting k8s namespace: %s", err)
+					continue
 				}
-
-				log.Printf("K8s namespace deleted: %s", namespace.Name)
 			}
+
+			log.Printf("K8s namespace deleted: %s", namespace.Name)
 		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Currently when a PR is merged regardless of wheather the env is ephemeral or not, the env will be deleted. In this PR, I added a condition that will stop the deletion of the env if the PR is merged and the env is non-ephemeral