### PR TITLE
Increate deploy timeout to 10m

### DIFF
--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -123,7 +123,7 @@ install_resources () {
     kubectl rollout restart -n "$namespace" deployment/kube-review-deployment    
   fi
 
-  if kubectl rollout status --timeout=5m -n "$namespace" deployment/kube-review-deployment; then
+  if kubectl rollout status --timeout=10m -n "$namespace" deployment/kube-review-deployment; then
     echo "Rollout successfully executed"
   else
     echo "Rollout was not Successful... Describing Deployed Pods"


### PR DESCRIPTION
I've resisted this change in the past, but I think it's necessary. Instances take a long time to get ready, sometimes more than 5 minutes. So, if we try to deploy and there is no room in the cluster, it will take a while for a new instance to get ready. This is especially true with the labrador project, which uses big instances.
