### PR TITLE
Add support for shared path

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -46,6 +46,7 @@ The `deploy` command contains many options which can be passed as environment va
 | KR_BASE_OVERLAY_PATH | The path containing the base kustomize overlay to be used. | src/deploy/resources/base | false |
 | KR_OVERLAY_PATH | The path containing a kustomize overlay to be used. | - | false |
 | KR_VERBOSE | Prints verbose or debug messages. Should not be used in production. | false | false |
+| KR_SHARED_PATH | The path of a folder that will be copied to `__shared_path/` folder into the overlay path. Can be used to load files from the host as configMaps, for example. | - | false |
 
 ### Restart Command
 

--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -33,6 +33,7 @@ url=https://$host
 kube_context=$KR_KUBE_CONTEXT
 test_connection=${KR_TEST_CONNECTION:-true}
 test_connection_url_path=${KR_TEST_CONNECTION_URL_PATH:-"/"}
+shared_path=$KR_SHARED_PATH
 overlay_path=$KR_OVERLAY_PATH
 base_overlay_path=${KR_BASE_OVERLAY_PATH:-"src/deploy/resources/base"}
 delete_before_apply=${KR_DELETE_BEFORE_APPLY:-false}
@@ -67,6 +68,10 @@ config_context() {
 install_resources () {
   # Prepare directory structure and copy files
   work_dir=$(mktemp -d)
+
+  if [ "$shared_path" != "" ]; then
+    cp -R "$shared_path" "$work_dir"
+  fi
 
   # If we don't have a overlay to apply, we just run from base overlay
   cp -R "$base_overlay_path" "$work_dir"

--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -69,10 +69,6 @@ install_resources () {
   # Prepare directory structure and copy files
   work_dir=$(mktemp -d)
 
-  if [ "$shared_path" != "" ]; then
-    cp -R "$shared_path" "$work_dir/shared_path"
-  fi
-
   # If we don't have a overlay to apply, we just run from base overlay
   cp -R "$base_overlay_path" "$work_dir"
   if [ "$overlay_path" != "" ]; then
@@ -92,6 +88,11 @@ install_resources () {
   cd "$work_dir/base"
   if [ "$overlay_path" != "" ]; then
     cd "$work_dir/overlay"
+  fi
+
+  # Copy files to shared path if it is present
+  if [ "$shared_path" != "" ]; then
+    cp -R "$shared_path" "./__shared_path"
   fi
 
   kustomize edit set namespace "$namespace"

--- a/src/deploy/deploy
+++ b/src/deploy/deploy
@@ -70,7 +70,7 @@ install_resources () {
   work_dir=$(mktemp -d)
 
   if [ "$shared_path" != "" ]; then
-    cp -R "$shared_path" "$work_dir"
+    cp -R "$shared_path" "$work_dir/shared_path"
   fi
 
   # If we don't have a overlay to apply, we just run from base overlay


### PR DESCRIPTION
Add support for shared path, a path that when provided by the user will be copied to the root of overlay, from which the kustomize will execute. This path will then be available as a special folder named `__shared_path`, which can be referenced in the kustomize:

```
configMapGenerator:
  - name: shared-path
    files:
    - __shared_path/bar.sh
    - __shared_path/foo.sh
```

With this, one can use Kustomize configMapGenerator, to load files from the host into Kubernetes, that later can be mounted as a volume. Useful when one has a script that needs to be executed by a resource in Kubernetes but the resource is not available in an image.